### PR TITLE
Add suport for list comprehensions

### DIFF
--- a/prices/__init__.py
+++ b/prices/__init__.py
@@ -89,6 +89,9 @@ class Price(namedtuple('Price', 'net gross currency history')):
                          currency=self.currency, history=history)
         return NotImplemented
 
+    def __radd__(self, other):
+        return self
+
     def __sub__(self, other):
         if isinstance(other, Price):
             if other.currency != self.currency:

--- a/prices/tests.py
+++ b/prices/tests.py
@@ -93,6 +93,11 @@ class PriceTest(unittest.TestCase):
         self.assertEqual(repr(p),
                          "Price(net='10', gross='20', currency='GBP')")
 
+    def test_sum(self):
+        total_sum = sum([self.ten_btc, self.twenty_btc])
+        total = self.ten_btc + self.twenty_btc
+        self.assertEqual(total, total_sum)
+
 
 class PriceRangeTest(unittest.TestCase):
 


### PR DESCRIPTION
Fixed `TypeError` when using `sum([price1, price2])`.
