### PR TITLE
Check explicitly values for `!=` operator

### DIFF
--- a/prices/__init__.py
+++ b/prices/__init__.py
@@ -67,7 +67,7 @@ class Price(namedtuple('Price', 'net gross currency history')):
         return False
 
     def __ne__(self, other):
-        return NotImplemented
+        return not self == other
 
     def __mul__(self, other):
         try:
@@ -217,7 +217,7 @@ class PriceRange(namedtuple('PriceRange', 'min_price max_price')):
         return False
 
     def __ne__(self, other):
-        return NotImplemented
+        return not self == other
 
     def __contains__(self, item):
         if not isinstance(item, Price):

--- a/prices/tests.py
+++ b/prices/tests.py
@@ -53,7 +53,6 @@ class PriceTest(unittest.TestCase):
         self.assertNotEqual(p1, p4)
         self.assertNotEqual(p1, p5)
         self.assertNotEqual(p1, 10)
-        self.assertTrue(p1 == p2)
         self.assertFalse(p1 != p2)
 
     def test_comparison(self):
@@ -169,7 +168,6 @@ class PriceRangeTest(unittest.TestCase):
         self.assertNotEqual(pr1, pr3)
         self.assertNotEqual(pr1, pr4)
         self.assertNotEqual(pr1, self.ten_btc)
-        self.assertTrue(pr1 == pr2)
         self.assertFalse(pr1 != pr2)
 
     def test_membership(self):

--- a/prices/tests.py
+++ b/prices/tests.py
@@ -53,6 +53,8 @@ class PriceTest(unittest.TestCase):
         self.assertNotEqual(p1, p4)
         self.assertNotEqual(p1, p5)
         self.assertNotEqual(p1, 10)
+        self.assertTrue(p1 == p2)
+        self.assertFalse(p1 != p2)
 
     def test_comparison(self):
         self.assertTrue(self.ten_btc < self.twenty_btc)
@@ -167,6 +169,8 @@ class PriceRangeTest(unittest.TestCase):
         self.assertNotEqual(pr1, pr3)
         self.assertNotEqual(pr1, pr4)
         self.assertNotEqual(pr1, self.ten_btc)
+        self.assertTrue(pr1 == pr2)
+        self.assertFalse(pr1 != pr2)
 
     def test_membership(self):
         self.assertTrue(self.ten_btc in self.range_ten_twenty)


### PR DESCRIPTION
This PR fixes comparison of prices for `!=` operator. 
An example of faulty result on *mac* (tested on python 2.7.9 and 3.4.2):
```
>>> Price(net='10', gross='20') != Price(net='10', gross='20')
True
```