### PR TITLE
Add as_tuple method that represents a decimal value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: python
 python:
   - 2.6
   - 2.7
-  - 3.2
-  - 3.3
+  - 3.4
+  - 3.5
 install:
   - python setup.py install
   - pip install coverage

--- a/prices/__init__.py
+++ b/prices/__init__.py
@@ -125,6 +125,9 @@ class Price(namedtuple('Price', 'net gross currency history')):
                          currency=self.currency, history=history)
         return NotImplemented
 
+    def as_tuple(self):
+        return self.net.as_tuple()
+
     @property
     def tax(self):
         return self.gross - self.net

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,10 @@ CLASSIFIERS = [
     'License :: OSI Approved :: BSD License',
     'Operating System :: OS Independent',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2.5',
     'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3.2',
-    'Programming Language :: Python :: 3.3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
     'Topic :: Software Development :: Libraries :: Python Modules',
 ]
 


### PR DESCRIPTION
`Price` object is the default value of `PriceField`, whose `Django` validates as a `DecimalField` using  [DecimalValidator](https://github.com/django/django/blob/master/django/core/validators.py#L380). This PR allows `Price` to pass the test.