### PR TITLE
Don't install typing if python version if >= 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
     version='1.0.0',
     url='https://github.com/mirumee/prices',
     packages=['prices'],
-    install_requires=['babel>=2.5.0', 'typing>=3.6.0'],
+    install_requires=['babel>=2.5.0', 'typing>=3.6.0;python_version<"3.5"'],
     classifiers=CLASSIFIERS,
     platforms=['any'])


### PR DESCRIPTION
It breaks pip, see https://github.com/mbarkhau/pycalver/pull/148